### PR TITLE
Bumped version number in docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Automatically exporting a sprite to a given format is documented here: <https://
 
 # Docs
 
-Documentation is on [docs.rs](https://docs.rs/aseprite/0.1.1/aseprite/)
+Documentation is on [docs.rs](https://docs.rs/aseprite/0.1.3/aseprite/)
 
 # Example
 


### PR DESCRIPTION
The URL to the documentation was still pointing to version 0.1.1.