### PR TITLE
chore: add GitHub Actions CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,91 @@
+name: CI
+on:
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+
+jobs:
+  rustfmt:
+    name: Formatter check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  # Run compile check on Linux, macOS, and Windows
+  # On both Rust stable and Rust nightly
+  compile:
+    name: Compile
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        toolchain: [stable, nightly]
+    steps:
+      # Checkout the branch being tested
+      - uses: actions/checkout@v3
+
+      # Install rust
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      # Cache the built dependencies
+      - uses: Swatinem/rust-cache@v2.2.1
+        with:
+          save-if: ${{ github.event_name == 'push' }}
+
+      # Install cargo-hack
+      - uses: taiki-e/install-action@cargo-hack
+
+      # Compile all feature combinations on the target platform
+      - name: Compile
+        run: cargo hack --feature-powerset check
+
+  # Run tests on Linux
+  # On both Rust stable and Rust nightly
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, nightly]
+    steps:
+      # Checkout the branch being tested
+      - uses: actions/checkout@v3
+
+      # Install rust
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      # Cache the built dependencies
+      - uses: Swatinem/rust-cache@v2.2.1
+        with:
+          save-if: ${{ github.event_name == 'push' }}
+
+      # Install cargo-hack
+      - uses: taiki-e/install-action@cargo-hack
+
+      # Run the ignored tests that expect the above setup
+      - name: Run all tests
+        run: cargo hack --feature-powerset test


### PR DESCRIPTION
This adds a CI that:

- Checks formatting using `rust fmt`
- Compiles both stable and nightly versions on Linux, macOS and Windows
- Tests all combinations of features (of which there are currently none) on Linux with both stable and nightly

The CI should currently fail on the formatting check step only, which should be fixed in #11.

@PSteinhaus 