### PR TITLE
chore(ci): automatically release with release-plz and simplify test CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    name: Release PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,17 +4,14 @@ on:
     paths-ignore:
       - "docs/**"
       - "**.md"
-  pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
 
 jobs:
+  # Check for formatting
   rustfmt:
     name: Formatter check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -29,63 +26,19 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  # Run compile check on Linux, macOS, and Windows
-  # On both Rust stable and Rust nightly
-  compile:
-    name: Compile
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-        toolchain: [stable, nightly]
-    steps:
-      # Checkout the branch being tested
-      - uses: actions/checkout@v3
-
-      # Install rust
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.toolchain }}
-
-      # Cache the built dependencies
-      - uses: Swatinem/rust-cache@v2.2.1
-        with:
-          save-if: ${{ github.event_name == 'push' }}
-
-      # Install cargo-hack
-      - uses: taiki-e/install-action@cargo-hack
-
-      # Compile all feature combinations on the target platform
-      - name: Compile
-        run: cargo hack --feature-powerset check
-
   # Run tests on Linux
-  # On both Rust stable and Rust nightly
   test:
     name: Test
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain: [stable, nightly]
     steps:
       # Checkout the branch being tested
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      # Install rust
+      # Install rust stable
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
 
-      # Cache the built dependencies
-      - uses: Swatinem/rust-cache@v2.2.1
-        with:
-          save-if: ${{ github.event_name == 'push' }}
-
-      # Install cargo-hack
-      - uses: taiki-e/install-action@cargo-hack
-
-      # Run the ignored tests that expect the above setup
-      - name: Run all tests
-        run: cargo hack --feature-powerset test
+      # Run the tests
+      - name: Test
+        run: cargo test


### PR DESCRIPTION
@icefoxen could you add the [`CARGO_REGISTRY_TOKEN` and `GITHUB_TOKEN` environment variables](https://release-plz.ieni.dev/docs/github/quickstart) for this repo so new releases can be published?